### PR TITLE
Using double quote instead of single quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Java 8 - either a Java Runtime Environment (JRE) or a Java Development Kit (JDK)
   Additional options to pass to java. Default value is `""`.
   - `slave_windows_labels`
   List of labels for the slave node. Default value is `['windows']`.
+  - `slave_windows_service_user`
+  The username to set the service to start as.
+  - `slave_windows_service_password`
+  The password of given username to set the service to start as.
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Java 8 - either a Java Runtime Environment (JRE) or a Java Development Kit (JDK)
   Agent name of the slave node. Default value is `agent`.
   - `slave_executors_num`
   Number of executors of the slave node. Default value is `1`.
+  - `slave_environments`
+  Dictionary of env variables to be set on slave. Default value is `{}`
   - `master_url`
   Jenkins master host URL. Default value is `http://{{ master_host }}:{{ master_port }}`.
 
@@ -74,9 +76,9 @@ Java 8 - either a Java Runtime Environment (JRE) or a Java Development Kit (JDK)
   - `slave_windows_labels`
   List of labels for the slave node. Default value is `['windows']`.
   - `slave_windows_service_user`
-  The username to set the service to start as.
+  The username to set the service to start as. Default value is `LocalSystem`
   - `slave_windows_service_password`
-  The password of given username to set the service to start as.
+  The password of given username to set the service to start as. Default value is `""`
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ master_url: "http://{{ master_host }}:{{ master_port }}"
 # general slave
 slave_agent_name: agent
 slave_executors_num: 1
+slave_environments: {}
 
 # jenkins linux slave
 slave_linux_host: "{{ ansible_host }}"
@@ -32,3 +33,4 @@ slave_windows_labels:
   - windows
 slave_windows_service_user: LocalSystem
 slave_windows_service_password:
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,5 @@ slave_windows_workdir: C:/Jenkins_Slave
 slave_windows_java_opts: ""
 slave_windows_labels:
   - windows
+slave_windows_service_user: LocalSystem
+slave_windows_service_password:

--- a/tasks/Win32NT/service.yml
+++ b/tasks/Win32NT/service.yml
@@ -19,3 +19,5 @@
   win_service:
     name: '{{ slave_windows_service }}'
     state: started
+    username: '{{ slave_windows_service_user }}'
+    password: '{{ slave_windows_service_password }}'

--- a/templates/add_linux_slave.groovy.j2
+++ b/templates/add_linux_slave.groovy.j2
@@ -8,6 +8,12 @@ import hudson.slaves.DumbSlave
 import hudson.util.VariableResolver
 import jenkins.model.Jenkins
 
+envs = new LinkedList()
+{% for item in (slave_environments | dict2items) %}
+env = new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("{{ item.key }}", "{{ item.value }}"))
+envs.add(env)
+{% endfor %}
+
 Jenkins jenkins = Jenkins.getInstance()
 
 String nodeHostname = "{{ slave_linux_host }}"
@@ -21,7 +27,8 @@ ComputerLauncher nodeLauncher = new SSHLauncher( nodeHostname, nodePort,
 String nodeName = "{{ slave_agent_name }}"
 String nodeRemoteFS = "{{ slave_linux_home }}"
 
-Node node = new DumbSlave( nodeName, nodeRemoteFS, nodeLauncher )
+Node node = new DumbSlave(nodeName, nodeRemoteFS, nodeLauncher)
 node.setNumExecutors({{ slave_executors_num }})
 node.setLabelString("{{ slave_linux_labels | join(' ') }}")
+node.setnodeProperties(envs)
 jenkins.addNode(node)

--- a/templates/add_windows_slave.groovy.j2
+++ b/templates/add_windows_slave.groovy.j2
@@ -3,13 +3,20 @@ import hudson.model.*
 import hudson.slaves.*
 import hudson.slaves.EnvironmentVariablesNodeProperty.Entry
 
+envs = new LinkedList()
+{% for item in (slave_environments | dict2items) %}
+env = new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("{{ item.key }}", "{{ item.value }}"))
+envs.add(env)
+{% endfor %}
+
 ComputerLauncher launcher = new JNLPLauncher()
-Slave slave = new DumbSlave( "{{ slave_agent_name }}",
-                             "{{ slave_windows_workdir }}",
-                             launcher )
+Slave slave = new DumbSlave("{{ slave_agent_name }}",
+                            "{{ slave_windows_workdir }}",
+                            launcher)
 slave.numExecutors = {{ slave_executors_num }}
 slave.labelString = "{{ slave_windows_labels | join(" ") }}"
 slave.mode = Node.Mode.NORMAL
 slave.retentionStrategy = new RetentionStrategy.Always()
+slave.nodeProperties = envs
 Jenkins.instance.addNode(slave)
 print slave.getComputer().getJnlpMac()

--- a/templates/service.cmd.j2
+++ b/templates/service.cmd.j2
@@ -1,1 +1,1 @@
-java.exe -Xrs {{ slave_windows_java_opts }} -jar '{{ slave_windows_workdir }}/slave.jar' -jnlpUrl {{ master_url }}/computer/{{ slave_agent_name }}/slave-agent.jnlp -secret {{ jenkins_slave_secret }}
+java.exe -Xrs {{ slave_windows_java_opts }} -jar "{{ slave_windows_workdir }}/slave.jar" -jnlpUrl {{ master_url }}/computer/{{ slave_agent_name }}/slave-agent.jnlp -secret {{ jenkins_slave_secret }}


### PR DESCRIPTION
In our environment, and I don't explain why. When using single quote `'` I have this error when service is starting

```
Unable to access jarfile `...`
```

By replacing single quote `'` by double quote `"` that fix issue.