### PR TITLE
Add slave_mode_exclusive variable handling for Node mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Java 8 - either a Java Runtime Environment (JRE) or a Java Development Kit (JDK)
   Agent name of the slave node. Default value is `agent`.
   - `slave_executors_num`
   Number of executors of the slave node. Default value is `1`.
+  - `slave_mode_exclusive`
+  Set usage of this node. If true, node will only build jobs with matching label expressions. Default value is `false`.
   - `master_url`
   Jenkins master host URL. Default value is `http://{{ master_host }}:{{ master_port }}`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ master_url: "http://{{ master_host }}:{{ master_port }}"
 # general slave
 slave_agent_name: agent
 slave_executors_num: 1
+slave_mode_exclusive: false
 
 # jenkins linux slave
 slave_linux_host: "{{ ansible_host }}"

--- a/templates/add_linux_slave.groovy.j2
+++ b/templates/add_linux_slave.groovy.j2
@@ -24,4 +24,9 @@ String nodeRemoteFS = "{{ slave_linux_home }}"
 Node node = new DumbSlave( nodeName, nodeRemoteFS, nodeLauncher )
 node.setNumExecutors({{ slave_executors_num }})
 node.setLabelString("{{ slave_linux_labels | join(' ') }}")
+{% if slave_mode_exclusive %}
+node.setMode(Node.Mode.EXCLUSIVE)
+{% else %}
+node.setMode(Node.Mode.NORMAL)
+{% endif %}
 jenkins.addNode(node)

--- a/templates/add_windows_slave.groovy.j2
+++ b/templates/add_windows_slave.groovy.j2
@@ -9,7 +9,11 @@ Slave slave = new DumbSlave( "{{ slave_agent_name }}",
                              launcher )
 slave.numExecutors = {{ slave_executors_num }}
 slave.labelString = "{{ slave_windows_labels | join(" ") }}"
+{% if slave_mode_exclusive %}
+slave.mode = Node.Mode.EXCLUSIVE
+{% else %}
 slave.mode = Node.Mode.NORMAL
+{% endif %}
 slave.retentionStrategy = new RetentionStrategy.Always()
 Jenkins.instance.addNode(slave)
 print slave.getComputer().getJnlpMac()


### PR DESCRIPTION
Allow specifying `slave_mode_exclusive` boolean variable to control how
the node will be used for builds.
  True:  Node.Mode.EXCLUSIVE will be set. Builds will only be taken by this
         node if the build label array overlaps the node label array.
  False: Node.Mode.NORMAL will be set. Any builds will be scheduled on this
         node unless they are configured for specific hosts.

Default is False.