### PR TITLE
Fix sshd service naming for different distributives

### DIFF
--- a/tasks/Linux/Linux.yml
+++ b/tasks/Linux/Linux.yml
@@ -1,7 +1,7 @@
 ---
 - name: Start and enable openssh server
   service:
-    name: {{ sshd_service_name }}'
+    name: '{{ sshd_service_name }}'
     state: started
     enabled: true
   become: true

--- a/tasks/Linux/Linux.yml
+++ b/tasks/Linux/Linux.yml
@@ -1,7 +1,7 @@
 ---
 - name: Start and enable openssh server
   service:
-    name: "{{ sshd_service_name }}"
+    name: {{ sshd_service_name }}'
     state: started
     enabled: true
   become: true

--- a/tasks/Linux/Linux.yml
+++ b/tasks/Linux/Linux.yml
@@ -1,7 +1,7 @@
 ---
 - name: Start and enable openssh server
   service:
-    name: sshd
+    name: "{{ sshd_service_name }}"
     state: started
     enabled: true
   become: true

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,3 +6,4 @@ requirements:
   - "wget"
   - "lsof"
   - "unzip"
+sshd_service_name: "ssh"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,3 +6,4 @@ requirements:
   - "wget"
   - "lsof"
   - "unzip"
+sshd_service_name: "sshd"

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -1,2 +1,3 @@
 ---
 requirements: []
+sshd_service_name: "ssh"

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,2 +1,3 @@
 ---
 requirements: []
+sshd_service_name: "ssh"


### PR DESCRIPTION
# Fix sshd service naming for different OSes

## Description

service sshd has differend naming in debian-based and RH-based linux distributions. Add flexible naming, dependent on distribution.