### PR TITLE
create and use the home directory as part of creating jenkins user

### DIFF
--- a/tasks/Linux/Linux.yml
+++ b/tasks/Linux/Linux.yml
@@ -16,11 +16,12 @@
   user:
     name: '{{ slave_linux_jenkins_username }}'
     group: '{{ slave_linux_jenkins_username }}'
+    home: '{{ slave_linux_home }}'
     password: >-
       {{ slave_linux_jenkins_password
         | password_hash('sha512', 65534 | random(seed=inventory_hostname)
         | string) }}
-    update_password: always
+    update_password: on_create
     state: present
     append: true
     createhome: true
@@ -33,15 +34,6 @@
     key: '{{ slave_linux_jenkins_public_key }}'
   become: true
   when: slave_linux_jenkins_public_key | trim
-
-- name: Create slave home directory
-  file:
-    path: '{{ slave_linux_home }}'
-    state: directory
-    owner: '{{ slave_linux_jenkins_username }}'
-    group: '{{ slave_linux_user_group }}'
-    mode: 0775
-  become: true
 
 - name: Install slave jenkins agent
   jenkins_script:


### PR DESCRIPTION
# Pull Request Template

## Description

Create and use the home directory as part of the user creation. Currently the home directory is not actually used, even though it is created.
Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Reviews

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass with my changes
